### PR TITLE
Make sure linting doesn't fail when added/updated files have spaces in them

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -40,6 +40,9 @@ module Danger
       swift_files = files ? Dir.glob(files) : (modified_files + added_files)
       swift_files.select! do |line| line.end_with?(".swift") end
 
+      # Make sure we don't fail when paths have spaces
+      swift_files = swift_files.map { |file| "\"#{file}\"" }
+
       swiftlint_command = "swiftlint lint --quiet --reporter json"
       swiftlint_command += " --config #{config_file}" if config_file
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -5,7 +5,7 @@ module Danger
     it 'is a plugin' do
       expect(Danger::DangerSwiftlint < Danger::Plugin).to be_truthy
     end
-    
+
     describe 'with Dangerfile' do
       before do
         @dangerfile = testing_dangerfile
@@ -34,7 +34,7 @@ module Danger
         end
 
         it 'handles a known SwiftLint report' do
-          allow(@swiftlint).to receive(:`).with('swiftlint lint --quiet --reporter json --path spec/fixtures/SwiftFile.swift').and_return(@swiftlint_response)
+          allow(@swiftlint).to receive(:`).with('swiftlint lint --quiet --reporter json --path "spec/fixtures/SwiftFile.swift"').and_return(@swiftlint_response)
 
           # Do it
           @swiftlint.lint_files("spec/fixtures/*.swift")
@@ -52,7 +52,7 @@ module Danger
         it 'handles no files' do
           allow(@swiftlint).to receive(:modified_files).and_return(['spec/fixtures/SwiftFile.swift'])
           allow(@swiftlint).to receive(:added_files).and_return([])
-          allow(@swiftlint).to receive(:`).with('swiftlint lint --quiet --reporter json --path spec/fixtures/SwiftFile.swift').and_return(@swiftlint_response)
+          allow(@swiftlint).to receive(:`).with('swiftlint lint --quiet --reporter json --path "spec/fixtures/SwiftFile.swift"').and_return(@swiftlint_response)
 
           @swiftlint.lint_files
 
@@ -61,7 +61,7 @@ module Danger
 
         it 'uses a config file' do
           @swiftlint.config_file = 'some_config.yml'
-          allow(@swiftlint).to receive(:`).with('swiftlint lint --quiet --reporter json --config some_config.yml --path spec/fixtures/SwiftFile.swift').and_return(@swiftlint_response)
+          allow(@swiftlint).to receive(:`).with('swiftlint lint --quiet --reporter json --config some_config.yml --path "spec/fixtures/SwiftFile.swift"').and_return(@swiftlint_response)
 
           @swiftlint.lint_files("spec/fixtures/*.swift")
 


### PR DESCRIPTION
Small change to make sure danger-swiftlint works with files with spaces in them. 

I'm not entirely sure whether this is the best way (not a Ruby master here) so I'm very open to suggestions! 