### PR TITLE
Run swiftlint from a custom directory

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -18,6 +18,9 @@ module Danger
     # Allows you to specify a config file location for swiftlint.
     attr_accessor :config_file
 
+    # Allows you to specify a directory from where swiftlint will be run. 
+    attr_accessor :directory
+
     # Lints Swift files. Will fail if `swiftlint` cannot be installed correctly.
     # Generates a `markdown` list of warnings for the prose in a corpus of .markdown and .md files. 
     #
@@ -36,11 +39,13 @@ module Danger
         return
       end
 
-      swiftlint_command = "swiftlint lint --quiet --reporter json"
+      swiftlint_command = ""
+      swiftlint_command += "cd #{directory} && " if directory
+      swiftlint_command += "swiftlint lint --quiet --reporter json"
       swiftlint_command += " --config #{config_file}" if config_file
 
       require 'json'
-      result_json = JSON.parse(`#{swiftlint_command}`).flatten
+      result_json = JSON.parse(`(#{swiftlint_command})`).flatten
 
       # Convert to swiftlint results
       warnings = result_json.select do |results| 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -42,7 +42,7 @@ module Danger
         end
 
         it 'handles a known SwiftLint report' do
-          allow(@swiftlint).to receive(:`).with('swiftlint lint --quiet --reporter json').and_return(@swiftlint_response)
+          allow(@swiftlint).to receive(:`).with('(swiftlint lint --quiet --reporter json)').and_return(@swiftlint_response)
 
           # Do it
           @swiftlint.lint_files
@@ -58,7 +58,7 @@ module Danger
         end
 
         it 'handles no files' do
-          allow(@swiftlint).to receive(:`).with('swiftlint lint --quiet --reporter json').and_return(@swiftlint_response)
+          allow(@swiftlint).to receive(:`).with('(swiftlint lint --quiet --reporter json)').and_return(@swiftlint_response)
 
           @swiftlint.lint_files
 
@@ -67,13 +67,21 @@ module Danger
 
         it 'uses a config file' do
           @swiftlint.config_file = 'some_config.yml'
-          allow(@swiftlint).to receive(:`).with('swiftlint lint --quiet --reporter json --config some_config.yml').and_return(@swiftlint_response)
+          allow(@swiftlint).to receive(:`).with('(swiftlint lint --quiet --reporter json --config some_config.yml)').and_return(@swiftlint_response)
 
           @swiftlint.lint_files
 
           expect(@swiftlint.status_report[:markdowns].first).to_not be_empty
         end
 
+        it 'uses a custom directory' do
+          @swiftlint.directory = 'some_dir'
+          allow(@swiftlint).to receive(:`).with('(cd some_dir && swiftlint lint --quiet --reporter json)').and_return(@swiftlint_response)
+
+          @swiftlint.lint_files
+
+          expect(@swiftlint.status_report[:markdowns].first).to_not be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
In our current project, we want to lint just the files in a subdirectory, but we'd like to have `.swiftlint.yml` only on that directory.

I've tried using `include:` in the config file, but that doesn't work when `swiftlint` is run from the root of the repository. 

This PR enables changing the current directory before running `swiftlint` and solves the issue for us.