### PR TITLE
Do not lint excluded files

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -76,9 +76,12 @@ module Danger
 
           require 'find'
           swift_files = swift_files.reject do |file|
-            excluded_dirs.reduce(false) do |accumulator, excluded_dir|
-              accumulator = accumulator || Find.find(excluded_dir).include?(file)
+            found = false
+            excluded_dirs.each do |excluded_dir|
+              found = Find.find(File.expand_path(excluded_dir)).include?(File.expand_path(file))
+              break if found
             end
+            found
           end
 
           # Make sure we don't fail when paths have spaces

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -52,6 +52,7 @@ module Danger
 
           excluded_dirs = danger_compatible_config['excluded']
             .map { |path| File.dirname(config_file) + '/' + path }
+            .select { |path| File.exists?(File.expand_path(path)) || Dir.exists?(File.expand_path(path)) }
 
           File.write(temp_config_file.path, danger_compatible_config.to_yaml)
 

--- a/spec/fixtures/excluded_dir/SwiftFileThatShouldNotBeIncluded.swift
+++ b/spec/fixtures/excluded_dir/SwiftFileThatShouldNotBeIncluded.swift
@@ -1,0 +1,1 @@
+// This file intentional left blank-ish.

--- a/spec/fixtures/some_config.yml
+++ b/spec/fixtures/some_config.yml
@@ -5,4 +5,4 @@ included:
   - an/included/folder
 
 excluded:
-  - an/excluded/folder
+  - excluded_dir


### PR DESCRIPTION
Because our plugin runs on all the files added or modified by the PR, unless a directory is given, we end up ignoring the "excluded" configuration that users might have in the `.swiftlint.yml`.

This can be problematic in projects that track things like the Carthage/Checkout folder in the repo. Two reasons:

- First of all the repos is set to exclude such directories, we should do the same; also
- A PR that updates one or more of these might end up with a lot of SwiftLint warnings. This in turn might result in Danger comment making a **long** comment, exceeding the 65536 characters limit imposed by the GitHub APIs.

I feel this PR should be squashed and merged. I left the full commit history just to show the thought process  ¯\_(ツ)_/¯.