### PR TITLE
support for inline comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ swiftlint.config_file = '.swiftlint.yml'
 swiftlint.lint_files
 ```
 
+If you want the lint result shows in diff instead of comment, you can use `inline_mode` option. Violations that out of the diff will show in danger's fail or warn section.
+
+```rb
+swiftlint.lint_files inline_mode: true
+```
+
+
 ## Attribution
 
 Original structure, sequence, and organization of repo taken from [danger-prose](https://github.com/dbgrandi/danger-prose) by [David Grandinetti](https://github.com/dbgrandi/).

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -101,6 +101,18 @@ module Danger
           @swiftlint.config_file = 'spec/fixtures/some_config.yml'
           @swiftlint.lint_files
         end
+
+        it 'generates errors instead of markdown when use inline mode' do
+          allow(Swiftlint).to receive(:lint)
+            .with(hash_including(:path => 'spec/fixtures/SwiftFile.swift'))
+            .and_return(@swiftlint_response)
+
+          @swiftlint.lint_files("spec/fixtures/*.swift", inline_mode: true)
+
+          status = @swiftlint.status_report
+          expect(status[:errors]).to_not be_empty
+          expect(status[:markdowns]).to be_empty
+        end
       end
     end
   end


### PR DESCRIPTION
Since `danger` now [support inline comment](https://github.com/danger/danger/pull/412), maybe it will be more clearly to show violations in diff using inline comment.

Add a parameter to `lint_files` method to support this. (default to `false` so it won't change the current settings)