### PR TITLE
Add CLI command to print managed SwiftLint version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,10 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.3.0)
+    danger-swiftlint (0.16.1)
       danger
+      rake (~> 10.0)
+      thor (~> 0.19)
 
 GEM
   remote: https://rubygems.org/
@@ -17,12 +19,13 @@ GEM
       open4 (~> 1.3)
     coderay (1.1.1)
     colored (1.2)
+    colored2 (3.1.2)
     cork (0.2.0)
       colored (~> 1.2)
-    danger (4.0.3)
+    danger (4.3.0)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
-      colored (~> 1.2)
+      colored2 (~> 3.1)
       cork (~> 0.1)
       faraday (~> 0.9)
       faraday-http-cache (~> 1.0)
@@ -31,7 +34,7 @@ GEM
       octokit (~> 4.2)
       terminal-table (~> 1)
     diff-lcs (1.2.5)
-    faraday (0.10.0)
+    faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.3.1)
       faraday (~> 0.8)
@@ -52,7 +55,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    kramdown (1.13.1)
+    kramdown (1.13.2)
     listen (3.0.7)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
@@ -78,7 +81,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    public_suffix (2.0.4)
+    public_suffix (2.0.5)
     rake (10.5.0)
     rb-fsevent (0.9.7)
     rb-inotify (0.9.7)
@@ -104,7 +107,7 @@ GEM
     terminal-table (1.7.3)
       unicode-display_width (~> 1.1.1)
     thor (0.19.1)
-    unicode-display_width (1.1.2)
+    unicode-display_width (1.1.3)
 
 PLATFORMS
   ruby
@@ -120,8 +123,7 @@ DEPENDENCIES
   mocha-on-bacon
   prettybacon
   pry
-  rake (~> 10.0)
   rspec (~> 3.4)
 
 BUNDLED WITH
-   1.13.1
+   1.14.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.16.1)
+    danger-swiftlint (0.4.0)
       danger
       rake (~> 10.0)
       thor (~> 0.19)

--- a/bin/danger-swiftlint
+++ b/bin/danger-swiftlint
@@ -1,0 +1,21 @@
+#!/usr/bin/env ruby
+
+if $PROGRAM_NAME == __FILE__
+  $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+end
+require 'thor'
+require 'version'
+
+class DangerSwiftlintCLI < Thor
+  desc 'version', 'The version of the installed danger-swiftlint plugin'
+  def version
+    puts DangerSwiftlint::VERSION
+  end
+
+  desc 'swiftlint_version', 'The SwiftLint version used by the plugin'
+  def swiftlint_version
+    puts DangerSwiftlint::SWIFTLINT_VERSION
+  end
+end
+
+DangerSwiftlintCLI.start(ARGV)

--- a/danger-swiftlint.gemspec
+++ b/danger-swiftlint.gemspec
@@ -17,8 +17,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
   spec.extensions    = %w(ext/swiftlint/Rakefile)
+  spec.executables   = ['danger-swiftlint']
 
   spec.add_dependency 'danger'
+  spec.add_dependency 'thor', '~> 0.19'
   spec.add_dependency 'rake', '~> 10.0'
 
   # General ruby development

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,4 +1,4 @@
 module DangerSwiftlint
-  VERSION = "0.16.1".freeze
+  VERSION = "0.4.0".freeze
   SWIFTLINT_VERSION = "0.16.1".freeze
 end


### PR DESCRIPTION
As discussed in https://github.com/ashfurrow/danger-swiftlint/issues/31, this PR add a mini CLI to print the version of the managed SwiftLint binary, as well as one printing the plugin version, because why not.

In context with what discussed in the issues it also sets the plugin version to 0.4.0.