### PR TITLE
Exclude deleted files from list of files to lint

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Fixes deleted files being added to the list of files to lint. See [#34](https://github.com/ashfurrow/danger-swiftlint/pull/34).
+
 ## 0.4.0
 
 - Support for inline comments. See [#29](https://github.com/ashfurrow/danger-swiftlint/issues/28)

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -92,7 +92,7 @@ module Danger
     # @return [Array] swift files
     def find_swift_files(files=nil, excluded_files=[])
       # Assign files to lint
-      files = files ? Dir.glob(files) : git.modified_files + git.added_files
+      files = files ? Dir.glob(files) : (git.modified_files - git.deleted_files) + git.added_files
 
       # Filter files to lint
       return files.

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -80,7 +80,7 @@ module Danger
     def run_swiftlint(files, options)
       files
         .map { |file| options.merge({path: file})}
-        .map { |options| Swiftlint.lint(options)}
+        .map { |full_options| Swiftlint.lint(full_options)}
         .reject { |s| s == '' }
         .map { |s| JSON.parse(s).flatten }
         .flatten

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -102,9 +102,10 @@ module Danger
         map { |file| Shellwords.escape(file) }.
         # Remove dups
         uniq.
+        map { |file| File.expand_path(file) }.
         # Reject files excluded on configuration
         reject { |file|
-          excluded_files.any? { |excluded| Find.find(excluded).include?(File.expand_path(file)) }
+          excluded_files.any? { |excluded| Find.find(excluded).include?(file) }
         }
     end
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -9,6 +9,7 @@ module Danger
     describe 'with Dangerfile' do
       before do
         @swiftlint = testing_dangerfile.swiftlint
+        allow(@swiftlint.git).to receive(:deleted_files).and_return([])
       end
 
       it "handles swiftlint not being installed" do
@@ -99,6 +100,28 @@ module Danger
             .once
 
           @swiftlint.config_file = 'spec/fixtures/some_config.yml'
+          @swiftlint.lint_files
+        end
+
+        it 'does not lint deleted files paths' do
+          # Danger (4.3.0 at the time of writing) returns deleted files in the
+          # modified fiels array, which kinda makes sense.
+          # At linting time though deleted files should not be linted because
+          # they'd result in file not found errors.
+          allow(@swiftlint.git).to receive(:added_files).and_return([])
+          allow(@swiftlint.git).to receive(:modified_files).and_return([
+            'spec/fixtures/SwiftFile.swift',
+            'spec/fixtures/DeletedFile.swift'
+          ])
+          allow(@swiftlint.git).to receive(:deleted_files).and_return([
+            'spec/fixtures/DeletedFile.swift'
+          ])
+
+          expect(Swiftlint).to receive(:lint)
+            .with(hash_including(:path => 'spec/fixtures/SwiftFile.swift'))
+            .and_return(@swiftlint_response)
+            .once
+
           @swiftlint.lint_files
         end
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -33,7 +33,7 @@ module Danger
 
         it 'accept files as arguments' do
           expect(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => 'spec/fixtures/SwiftFile.swift'))
+            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
             .and_return(@swiftlint_response)
 
           @swiftlint.lint_files("spec/fixtures/*.swift")
@@ -47,7 +47,7 @@ module Danger
           allow(@swiftlint.git).to receive(:modified_files).and_return(['spec/fixtures/SwiftFile.swift'])
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => 'spec/fixtures/SwiftFile.swift'))
+            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
             .and_return(@swiftlint_response)
 
           @swiftlint.lint_files
@@ -95,7 +95,7 @@ module Danger
           ])
 
           expect(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => 'spec/fixtures/SwiftFile.swift'))
+            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
             .and_return(@swiftlint_response)
             .once
 
@@ -118,7 +118,7 @@ module Danger
           ])
 
           expect(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => 'spec/fixtures/SwiftFile.swift'))
+            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
             .and_return(@swiftlint_response)
             .once
 
@@ -127,7 +127,7 @@ module Danger
 
         it 'generates errors instead of markdown when use inline mode' do
           allow(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => 'spec/fixtures/SwiftFile.swift'))
+            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
             .and_return(@swiftlint_response)
 
           @swiftlint.lint_files("spec/fixtures/*.swift", inline_mode: true)


### PR DESCRIPTION
I noticed at work with [iflix](https://iflix.com) that every time we updated our Carthage dependencies, of which the sources are checked in the repo, we'd get a lot of `No lintable files found at path '...'` messages on the CI stderr.

After a bit of looking I realized that was due to the fact that `danger-swiftlint` was passing the paths of deleted files to SwiftLint for linting.

The reason for that is not a bug in our code to evaluate the paths of the files, but rather a different assumption on what the `git.modified_files` method exposed by Danger does.

Looking [at the source](https://github.com/danger/danger/blob/27537086daac9b96481438040dda00e39bd4c505/lib/danger/danger_core/plugins/dangerfile_git_plugin.rb#L62-L76) we can see that `modified_files` return both deleted and edited files.

```ruby
# @!group Git Files
# Paths for files that were removed during the diff
# @return [FileList<String>] an [Array] subclass
#
def deleted_files
  Danger::FileList.new(@git.diff.select { |diff| diff.type == "deleted" }.map(&:path))
end

# @!group Git Files
# Paths for files that changed during the diff
# @return [FileList<String>] an [Array] subclass
#
def modified_files
  Danger::FileList.new(@git.diff.stats[:files].keys)
end
```

From my point of view that behaviour is correct, so I updated our code to remove the `git.deleted_files` from the result of `git.modified_files` before processing them.