### PR TITLE
Bump SwiftLint version to 0.18.1

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,8 @@
 
 ## Current Master
 
+- Bump managed SwiftLint version to 0.18.1
+
 ## 0.4.1
 
 - Fixes deleted files being added to the list of files to lint. See [#34](https://github.com/ashfurrow/danger-swiftlint/pull/34).

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,4 +1,4 @@
 module DangerSwiftlint
   VERSION = "0.4.1".freeze
-  SWIFTLINT_VERSION = "0.16.1".freeze
+  SWIFTLINT_VERSION = "0.18.1".freeze
 end


### PR DESCRIPTION
New SwiftLint doesn't introduce some breaking changes for CLI, so it's just a simple version bump.

Fixes #33