### PR TITLE
Ensure excluded config exists

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -119,8 +119,10 @@ module Danger
         {"excluded" => []}
       end
 
+      excluded_paths = config['excluded'] || []
+
       # Extract excluded paths
-      return config['excluded'].
+      return excluded_paths.
         map { |path| File.join(File.dirname(config_file), path) }.
         map { |path| File.expand_path(path) }.
         select { |path| File.exists?(path) || Dir.exists?(path) }

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -103,6 +103,21 @@ module Danger
           @swiftlint.lint_files
         end
 
+        it 'does not crash when excluded is nil' do
+          allow(@swiftlint.git).to receive(:added_files).and_return([])
+          allow(@swiftlint.git).to receive(:modified_files).and_return([
+            'spec/fixtures/SwiftFile.swift',
+          ])
+
+          expect(Swiftlint).to receive(:lint)
+            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
+            .and_return(@swiftlint_response)
+            .once
+
+          @swiftlint.config_file = 'spec/fixtures/empty_excluded.yml'
+          @swiftlint.lint_files
+        end
+
         it 'does not lint deleted files paths' do
           # Danger (4.3.0 at the time of writing) returns deleted files in the
           # modified fiels array, which kinda makes sense.

--- a/spec/fixtures/empty_excluded.yml
+++ b/spec/fixtures/empty_excluded.yml
@@ -1,0 +1,7 @@
+disabled_rules:
+  - todo
+
+included:
+  - an/included/folder
+
+excluded:


### PR DESCRIPTION
This ensures we don't attempt to call map on nil when swiftlint is
configured with an empty excluded key.

For example our swiftlint.yml has this:

```yml
excluded:
included:
  - folder
```

Which would make the plugin crash because `excluded` came in as `nil`. Since this is valid yml and swiftlint deals with it correctly I think danger-swiftlint should too.