### PR TITLE
Introduce `binary_path` option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.5.1)
+    danger-swiftlint (0.6.0)
       danger
       rake (> 10)
       thor (~> 0.19)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.5.0)
+    danger-swiftlint (0.5.1)
       danger
       rake (> 10)
       thor (~> 0.19)
@@ -12,7 +12,7 @@ GEM
     addressable (2.5.1)
       public_suffix (~> 2.0, >= 2.0.2)
     bacon (1.2.0)
-    claide (1.0.1)
+    claide (1.0.2)
     claide-plugins (0.9.2)
       cork
       nap
@@ -21,7 +21,7 @@ GEM
     colored2 (3.1.2)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (5.2.1)
+    danger (5.3.3)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -30,7 +30,7 @@ GEM
       faraday-http-cache (~> 1.0)
       git (~> 1)
       kramdown (~> 1.5)
-      octokit (~> 4.2)
+      octokit (~> 4.7)
       terminal-table (~> 1)
     diff-lcs (1.3)
     faraday (0.12.1)
@@ -54,7 +54,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    kramdown (1.13.2)
+    kramdown (1.14.0)
     listen (3.0.7)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
@@ -106,7 +106,7 @@ GEM
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
     thor (0.19.4)
-    unicode-display_width (1.2.1)
+    unicode-display_width (1.3.0)
 
 PLATFORMS
   ruby
@@ -125,4 +125,4 @@ DEPENDENCIES
   rspec (~> 3.4)
 
 BUNDLED WITH
-   1.14.6
+   1.15.0

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ That's going to lint all your Swift files. It would be better to only lint the c
 
 ```rb
 swiftlint.config_file = '.swiftlint.yml'
+swiftlint.binary_path = '/path/to/swiftlint'
 swiftlint.lint_files
 ```
 

--- a/ext/swiftlint/swiftlint.rb
+++ b/ext/swiftlint/swiftlint.rb
@@ -1,58 +1,60 @@
 
 class Swiftlint
-  class << self
-    # Runs swiftlint
-    # @param key (Symbol) the key which is used as command paramters or key in the fastlane tools
-    # @param env_name (String) the name of the environment variable, which is only used if no other values were found
-    # @param description (String) A description shown to the user
-    # @param sensitive (Boolean) Set if the variable is sensitive, such as a password or API token, to prevent echoing when prompted for the parameter
-    def run(cmd='lint', options={})
+  def initialize(swiftlint_path=nil)
+    @swiftlint_path = swiftlint_path
+  end
 
-      # change pwd before run swiftlint
-      if options.has_key? :pwd
-        Dir.chdir options.delete(:pwd)
-      end
-
-      # run swiftlint with provided options
-      `#{swiftlint_path} #{cmd} #{swiftlint_arguments(options)}`
+  # Runs swiftlint
+  def run(cmd='lint', options={})
+    # change pwd before run swiftlint
+    if options.has_key? :pwd
+      Dir.chdir options.delete(:pwd)
     end
 
-    # Shortcut for running the lint command
-    def lint(options)
-      run('lint', options)
-    end
+    # run swiftlint with provided options
+    `#{swiftlint_path} #{cmd} #{swiftlint_arguments(options)}`
+  end
 
-    # Return true if swiftlint is installed or false otherwise
-    def is_installed?
-      File.exist?(swiftlint_path)
-    end
+  # Shortcut for running the lint command
+  def lint(options)
+    run('lint', options)
+  end
 
-    private
+  # Return true if swiftlint is installed or false otherwise
+  def is_installed?
+    File.exist?(swiftlint_path)
+  end
 
-    # Parse options into shell arguments how swift expect it to be
-    # more information: https://github.com/Carthage/Commandant
-    # @param options (Hash) hash containing swiftlint options
-    def swiftlint_arguments options
-      options.
-        # filter not null
-        select {|key, value| !value.nil?}.
-        # map booleans arguments equal true
-        map { |key, value| value.is_a?(TrueClass) ? [key, ''] : [key, value] }.
-        # map booleans arguments equal false
-        map { |key, value| value.is_a?(FalseClass) ? ["no-#{key}", ''] : [key, value] }.
-        # replace underscore by hyphen
-        map { |key, value| [key.to_s.tr('_', '-'), value] }.
-        # prepend '--' into the argument
-        map { |key, value| ["--#{key}", value] }.
-        # reduce everything into a single string
-        reduce('') { |args, option| "#{args} #{option[0]} #{option[1]}" }.
-        # strip leading spaces
-        strip
-    end
+  # Return swiftlint execution path
+  def swiftlint_path
+    @swiftlint_path or default_swiftlint_path
+  end
 
-    # Path where swiftlint should be found
-    def swiftlint_path
-      File.expand_path(File.join(File.dirname(__FILE__), 'bin', 'swiftlint'))
-    end
+  private
+
+  # Parse options into shell arguments how swift expect it to be
+  # more information: https://github.com/Carthage/Commandant
+  # @param options (Hash) hash containing swiftlint options
+  def swiftlint_arguments options
+    options.
+      # filter not null
+      select {|key, value| !value.nil?}.
+      # map booleans arguments equal true
+      map { |key, value| value.is_a?(TrueClass) ? [key, ''] : [key, value] }.
+      # map booleans arguments equal false
+      map { |key, value| value.is_a?(FalseClass) ? ["no-#{key}", ''] : [key, value] }.
+      # replace underscore by hyphen
+      map { |key, value| [key.to_s.tr('_', '-'), value] }.
+      # prepend '--' into the argument
+      map { |key, value| ["--#{key}", value] }.
+      # reduce everything into a single string
+      reduce('') { |args, option| "#{args} #{option[0]} #{option[1]}" }.
+      # strip leading spaces
+      strip
+  end
+
+  # Path where swiftlint should be found
+  def default_swiftlint_path
+    File.expand_path(File.join(File.dirname(__FILE__), 'bin', 'swiftlint'))
   end
 end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -19,6 +19,8 @@ module Danger
   # @tags swift
   #
   class DangerSwiftlint < Plugin
+    # The path to SwiftLint's execution
+    attr_accessor :binary_path
 
     # The path to SwiftLint's configuration file
     attr_accessor :config_file
@@ -36,7 +38,7 @@ module Danger
     #
     def lint_files(files=nil, inline_mode: false)
       # Fails if swiftlint isn't installed
-      raise "swiftlint is not installed" unless Swiftlint.is_installed?
+      raise "swiftlint is not installed" unless swiftlint.is_installed?
 
       # Extract excluded paths
       excluded_paths = excluded_files_from_config(config_file)
@@ -80,7 +82,7 @@ module Danger
     def run_swiftlint(files, options)
       files
         .map { |file| options.merge({path: file})}
-        .map { |full_options| Swiftlint.lint(full_options)}
+        .map { |full_options| swiftlint.lint(full_options)}
         .reject { |s| s == '' }
         .map { |s| JSON.parse(s).flatten }
         .flatten
@@ -161,6 +163,13 @@ module Danger
 	filename = r['file'].gsub(dir, "")
 	send(method, r['reason'], file: filename, line: r['line'])
       end
+    end
+
+    # Make SwiftLint object for binary_path
+    #
+    # @return [SwiftLint]
+    def swiftlint
+      Swiftlint.new(binary_path)
     end
   end
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,4 +1,4 @@
 module DangerSwiftlint
-  VERSION = "0.5.1".freeze
+  VERSION = "0.6.0".freeze
   SWIFTLINT_VERSION = "0.18.1".freeze
 end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -22,6 +22,17 @@ module Danger
         expect(@swiftlint.status_report[:markdowns].first).to be_nil
       end
 
+      context 'with binary_path' do
+        let(:binary_path) { '/path/to/swiftlint' }
+        it 'passes binary_path to constructor' do
+          @swiftlint.binary_path = binary_path
+          swiftlint = double('swiftlint')
+          allow(Swiftlint).to receive(:new).with(binary_path).and_return(swiftlint)
+
+          expect(@swiftlint.swiftlint).to eql(swiftlint)
+        end
+      end
+
       describe :lint_files do
         before do
           allow_any_instance_of(Swiftlint).to receive(:is_installed?).and_return(true)

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -13,18 +13,18 @@ module Danger
       end
 
       it "handles swiftlint not being installed" do
-        allow(Swiftlint).to receive(:is_installed?).and_return(false)
+        allow_any_instance_of(Swiftlint).to receive(:is_installed?).and_return(false)
         expect { @swiftlint.lint_files }.to raise_error("swiftlint is not installed")
       end
 
       it 'does not markdown an empty message' do
-        allow(Swiftlint).to receive(:lint).and_return('[]')
+        allow_any_instance_of(Swiftlint).to receive(:lint).and_return('[]')
         expect(@swiftlint.status_report[:markdowns].first).to be_nil
       end
 
       describe :lint_files do
         before do
-          allow(Swiftlint).to receive(:is_installed?).and_return(true)
+          allow_any_instance_of(Swiftlint).to receive(:is_installed?).and_return(true)
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([])
 
@@ -32,7 +32,7 @@ module Danger
         end
 
         it 'accept files as arguments' do
-          expect(Swiftlint).to receive(:lint)
+          expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
             .and_return(@swiftlint_response)
 
@@ -46,7 +46,7 @@ module Danger
         it 'uses git diff when files are not provided' do
           allow(@swiftlint.git).to receive(:modified_files).and_return(['spec/fixtures/SwiftFile.swift'])
           allow(@swiftlint.git).to receive(:added_files).and_return([])
-          allow(Swiftlint).to receive(:lint)
+          allow_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
             .and_return(@swiftlint_response)
 
@@ -59,7 +59,7 @@ module Danger
         it 'uses a custom directory' do
           @swiftlint.directory = 'some_dir'
 
-          allow(Swiftlint).to receive(:lint)
+          allow_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(:pwd => @swiftlint.directory))
             .and_return(@swiftlint_response)
 
@@ -82,7 +82,7 @@ module Danger
           # would then become an empty string, which cannot be parsed into a
           # JSON object.
 
-          allow(Swiftlint).to receive(:lint).and_return('')
+          allow_any_instance_of(Swiftlint).to receive(:lint).and_return('')
 
           expect { @swiftlint.lint_files }.not_to raise_error
         end
@@ -95,10 +95,10 @@ module Danger
             'spec/fixtures/excluded_dir/SwiftFile WithEscaped+CharactersThatShouldNotBeIncluded.swift'
           ])
 
-          expect(Swiftlint).to receive(:lint)
+          expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
-            .and_return(@swiftlint_response)
             .once
+            .and_return(@swiftlint_response)
 
           @swiftlint.config_file = 'spec/fixtures/some_config.yml'
           @swiftlint.lint_files
@@ -110,10 +110,10 @@ module Danger
             'spec/fixtures/SwiftFile.swift',
           ])
 
-          expect(Swiftlint).to receive(:lint)
+          expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
-            .and_return(@swiftlint_response)
             .once
+            .and_return(@swiftlint_response)
 
           @swiftlint.config_file = 'spec/fixtures/empty_excluded.yml'
           @swiftlint.lint_files
@@ -133,16 +133,16 @@ module Danger
             'spec/fixtures/DeletedFile.swift'
           ])
 
-          expect(Swiftlint).to receive(:lint)
+          expect_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
-            .and_return(@swiftlint_response)
             .once
+            .and_return(@swiftlint_response)
 
           @swiftlint.lint_files
         end
 
         it 'generates errors instead of markdown when use inline mode' do
-          allow(Swiftlint).to receive(:lint)
+          allow_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
             .and_return(@swiftlint_response)
 

--- a/spec/swiftlint_spec.rb
+++ b/spec/swiftlint_spec.rb
@@ -11,6 +11,18 @@ describe Swiftlint do
     expect(swiftlint.is_installed?).to be_falsy
   end
 
+  context 'with binary_path' do
+    let(:binary_path) { '/path/to/swiftlint' }
+    let(:swiftlint) { Swiftlint.new(binary_path) }
+    it 'is_installed? works based on specific path' do
+      expect(File).to receive(:exist?).with(binary_path).and_return(true)
+      expect(swiftlint.is_installed?).to be_truthy
+
+      expect(File).to receive(:exist?).with(binary_path).and_return(false)
+      expect(swiftlint.is_installed?).to be_falsy
+    end
+  end
+
   it 'runs lint by default with options being optional' do
     expect(swiftlint).to receive(:`).with(including('swiftlint lint'))
     swiftlint.run()

--- a/spec/swiftlint_spec.rb
+++ b/spec/swiftlint_spec.rb
@@ -2,24 +2,25 @@ require File.expand_path('../spec_helper', __FILE__)
 require_relative '../ext/swiftlint/swiftlint'
 
 describe Swiftlint do
+  let(:swiftlint) { Swiftlint.new }
   it 'is_installed? works based on bin/swiftlint file' do
     expect(File).to receive(:exist?).with(/bin\/swiftlint/).and_return(true)
-    expect(Swiftlint.is_installed?).to be_truthy
+    expect(swiftlint.is_installed?).to be_truthy
 
     expect(File).to receive(:exist?).with(/bin\/swiftlint/).and_return(false)
-    expect(Swiftlint.is_installed?).to be_falsy
+    expect(swiftlint.is_installed?).to be_falsy
   end
 
   it 'runs lint by default with options being optional' do
-    expect(Swiftlint).to receive(:`).with(including('swiftlint lint'))
-    Swiftlint.run()
+    expect(swiftlint).to receive(:`).with(including('swiftlint lint'))
+    swiftlint.run()
   end
 
   it 'runs accepting symbolized options' do
     cmd = 'swiftlint lint --no-use-stdin  --cache-path /path --enable-all-rules'
-    expect(Swiftlint).to receive(:`).with(including(cmd))
+    expect(swiftlint).to receive(:`).with(including(cmd))
 
-    Swiftlint.run('lint',
+    swiftlint.run('lint',
                   use_stdin: false,
                   cache_path: '/path',
                   enable_all_rules: true)


### PR DESCRIPTION
closes #44 

# Motivation

I want to set execution path of SwiftLint

# Usage

If you installs SwiftLint via CocoaPods, you can use like following:

```ruby
swiftlint.binary_path = "./Pods/SwiftLint/swiftlint"
```

