### PR TITLE
Bump version to 0.7.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,10 @@
 
 - Nothing yet!
 
+## 0.7.0
+
+- Bump managed SwiftLint version to 0.20.1
+
 ## 0.6.0
 
 - Fixes problem with differing swiftlint paths. See [#44](https://github.com/ashfurrow/danger-swiftlint/issues/44).

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.6.0)
+    danger-swiftlint (0.7.0)
       danger
       rake (> 10)
       thor (~> 0.19)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,4 +1,4 @@
 module DangerSwiftlint
   VERSION = "0.6.0".freeze
-  SWIFTLINT_VERSION = "0.18.1".freeze
+  SWIFTLINT_VERSION = "0.20.1".freeze
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,4 +1,4 @@
 module DangerSwiftlint
-  VERSION = "0.6.0".freeze
+  VERSION = "0.7.0".freeze
   SWIFTLINT_VERSION = "0.20.1".freeze
 end


### PR DESCRIPTION
This bumps managed SwiftLint version to 0.20.1.

I think we should have a way to specify preferred SwiftLint version instead so everyone doesn't need to wait for this gem to be updated every time SwiftLint gets an update.