### PR TITLE
Fix directory not found error

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -51,7 +51,7 @@ module Danger
         config: config_file,
         reporter: 'json',
         quiet: true,
-        pwd: directory || Dir.pwd
+        pwd: directory ? File.expand_path(directory) : Dir.pwd
       }
 
       # Lint each file and collect the results

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -71,7 +71,7 @@ module Danger
           @swiftlint.directory = 'some_dir'
 
           allow_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:pwd => @swiftlint.directory))
+            .with(hash_including(:pwd => File.expand_path(@swiftlint.directory)))
             .and_return(@swiftlint_response)
 
           @swiftlint.lint_files("spec/fixtures/*.swift")


### PR DESCRIPTION
Hey, I'm having troubles with this when I'm trying to use the directory variable and I have more than one file changed in the branch.

The library is trying to change to the specified directory each time it tries to lint a file so the first time it works well but the second time the directory doesn't exist because it is already on it.

A more illustrative way to explain this:
I have a folder structure like this:

```
root
├── whatever
│	└── aRandomFile
└── iOS
 	└── ASwiftFile.swift
 	└── AnotherSwiftFile.swift
```
and I've specified the swiftlint.directory = 'iOS/', It will try to lint ASwiftFile.swift so first it will move to the specified directory and lint the file, the first time goes well. But the second time it is already on the folder iOS so the Dir.chdir [here](https://github.com/ashfurrow/danger-swiftlint/blob/master/ext/swiftlint/swiftlint.rb#L11) will fail.

I know I could use an absolute path to the directory and it should work, but with this approach, it will work with both absolute and relative.

I don't know how to write test for this, if you can help me I'll be happy to do them :)

I hope you find this useful

