### PR TITLE
When directory is specified, danger-swiftlint is still linting files outside the specified directory

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -116,7 +116,7 @@ module Danger
         uniq.
         map { |file| File.expand_path(file) }.
         # Ensure only files in the selected directory
-        select { |file| file.start_with?(dir_selected)}.
+        select { |file| file.start_with?(dir_selected) }.
         # Reject files excluded on configuration
         reject { |file|
           excluded_paths.any? { |excluded_path|

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -47,19 +47,21 @@ module Danger
       else
         nil
       end
+      
+      dir_selected = directory ? File.expand_path(directory) : Dir.pwd
 
       # Extract excluded paths
       excluded_paths = excluded_files_from_config(config)
 
       # Extract swift files (ignoring excluded ones)
-      files = find_swift_files(files, excluded_paths)
+      files = find_swift_files(files, excluded_paths, dir_selected)
 
       # Prepare swiftlint options
       options = {
         config: config,
         reporter: 'json',
         quiet: true,
-        pwd: directory ? File.expand_path(directory) : Dir.pwd
+        pwd: dir_selected
       }
 
       # Lint each file and collect the results
@@ -100,7 +102,7 @@ module Danger
     # If files are not provided it will use git modifield and added files
     #
     # @return [Array] swift files
-    def find_swift_files(files=nil, excluded_paths=[])
+    def find_swift_files(files=nil, excluded_paths=[], dir_selected)
       # Assign files to lint
       files = files ? Dir.glob(files) : (git.modified_files - git.deleted_files) + git.added_files
 
@@ -113,6 +115,8 @@ module Danger
         # Remove dups
         uniq.
         map { |file| File.expand_path(file) }.
+        # Ensure only files in the selected directory
+        select { |file| file.start_with?(dir_selected)}.
         # Reject files excluded on configuration
         reject { |file|
           excluded_paths.any? { |excluded_path|

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -84,19 +84,19 @@ module Danger
         it 'only lint files specified in custom dir' do
           @swiftlint.directory = 'spec/fixtures/some_dir'
         
-        allow(@swiftlint.git).to receive(:added_files).and_return([])
-        allow(@swiftlint.git).to receive(:modified_files).and_return([
+          allow(@swiftlint.git).to receive(:added_files).and_return([])
+          allow(@swiftlint.git).to receive(:modified_files).and_return([
             'spec/fixtures/some_dir/SwiftFile.swift',
             'spec/fixtures/SwiftFile.swift'
-        ])
+          ])
 
-        expect_any_instance_of(Swiftlint).to receive(:lint)
-        .with(hash_including(:path => File.expand_path('spec/fixtures/some_dir/SwiftFile.swift')))
-        .once
-        .and_return(@swiftlint_response)
+          expect_any_instance_of(Swiftlint).to receive(:lint)
+          .with(hash_including(:path => File.expand_path('spec/fixtures/some_dir/SwiftFile.swift')))
+          .once
+          .and_return(@swiftlint_response)
 
-        @swiftlint.lint_files
-          end
+          @swiftlint.lint_files
+        end
 
         it 'does not crash if JSON reporter returns an empty string rather than an object' do
           # This can occurr if for some reson there is no file at the give path.

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -68,17 +68,35 @@ module Danger
         end
 
         it 'uses a custom directory' do
-          @swiftlint.directory = 'some_dir'
+          @swiftlint.directory = 'spec/fixtures/some_dir'
 
           allow_any_instance_of(Swiftlint).to receive(:lint)
             .with(hash_including(:pwd => File.expand_path(@swiftlint.directory)))
             .and_return(@swiftlint_response)
 
-          @swiftlint.lint_files("spec/fixtures/*.swift")
+          @swiftlint.lint_files(["spec/fixtures/some_dir/SwiftFile.swift"])
 
           output = @swiftlint.status_report[:markdowns].first.to_s
           expect(output).to_not be_empty
+          
         end
+
+        it 'only lint files specified in custom dir' do
+          @swiftlint.directory = 'spec/fixtures/some_dir'
+        
+        allow(@swiftlint.git).to receive(:added_files).and_return([])
+        allow(@swiftlint.git).to receive(:modified_files).and_return([
+            'spec/fixtures/some_dir/SwiftFile.swift',
+            'spec/fixtures/SwiftFile.swift'
+        ])
+
+        expect_any_instance_of(Swiftlint).to receive(:lint)
+        .with(hash_including(:path => File.expand_path('spec/fixtures/some_dir/SwiftFile.swift')))
+        .once
+        .and_return(@swiftlint_response)
+
+        @swiftlint.lint_files
+          end
 
         it 'does not crash if JSON reporter returns an empty string rather than an object' do
           # This can occurr if for some reson there is no file at the give path.

--- a/spec/fixtures/some_dir/SwiftFile.swift
+++ b/spec/fixtures/some_dir/SwiftFile.swift
@@ -1,0 +1,1 @@
+// This file intentional left blank-ish.


### PR DESCRIPTION
Right now, when I run danger-swiftlint with a custom directory and I have also modified files outside this directory, danger-swiftlint is linting all the files.

With this PR danger-swiftlint will only lint the modified files inside the specified directory :)

If this PR gets approved, can you upload a new version of the Gem? Thanks in advance!

Any comment or question would be appreciated