### PR TITLE
Fail Danger on linting errors. Closes #54

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Fixes Directory not found error. See [#51](https://github.com/ashfurrow/danger-swiftlint/pull/51).
 - Fixes issue with missing `.swiftlint.yml` file. See [#52](https://github.com/ashfurrow/danger-swiftlint/pull/52).
+- Adds `fail_on_error` option. See [#55](https://github.com/ashfurrow/danger-swiftlint/pull/55)
 
 ## 0.7.0
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,12 @@ If you want the lint result shows in diff instead of comment, you can use `inlin
 swiftlint.lint_files inline_mode: true
 ```
 
+If you want lint errors to fail Danger, you can use `fail_on_error` option.
+
+```rb
+swiftlint.lint_files fail_on_error: true
+```
+
 You can use the `SWIFTLINT_VERSION` environment variable to override the default version installed via the `rake install` task.
 
 ## Attribution

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -83,7 +83,7 @@ module Danger
 
 	  # Fail Danger on errors
 	  if fail_on_error && errors.count > 0
-	    fail  
+	    fail "Failed due to SwiftLint errors"
 	  end
         end
       end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -36,7 +36,7 @@ module Danger
     #          if nil, modified and added files from the diff will be used.
     # @return  [void]
     #
-    def lint_files(files=nil, inline_mode: false)
+    def lint_files(files=nil, inline_mode: false, fail_on_error: false)
       # Fails if swiftlint isn't installed
       raise "swiftlint is not installed" unless swiftlint.is_installed?
 
@@ -80,6 +80,11 @@ module Danger
           message << markdown_issues(warnings, 'Warnings') unless warnings.empty?
           message << markdown_issues(errors, 'Errors') unless errors.empty?
           markdown message
+
+	  # Fail Danger on errors
+	  if fail_on_error && errors.count > 0
+	    fail  
+	  end
         end
       end
     end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -157,7 +157,7 @@ module Danger
             .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')))
             .and_return(@swiftlint_response)
 
-          @swiftlint.lint_files("spec/fixtures/*.swift", inline_mode: true)
+          @swiftlint.lint_files("spec/fixtures/*.swift", inline_mode: true, fail_on_error: false)
 
           status = @swiftlint.status_report
           expect(status[:errors]).to_not be_empty


### PR DESCRIPTION
Adding a new option, `fail_on_error` to fail Danger on linting errors only. I figured it would be best to make this opt-out, specially so it is backwards compatible with the behavior most users expect. Finally, with this option you'll ensure no one merges linting errors accidentally into `master` (cause, we can all be sloppy at times).

Closes https://github.com/ashfurrow/danger-swiftlint/issues/54