### PR TITLE
Add basic Rubocop support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,3 @@
+Metrics/LineLength:
+  Exclude:
+    - '*.gemspec'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,26 @@
+# Disable linting of Dangerfile.
+AllCops:
+  Exclude:
+    - 'Dangerfile'
+# Customize some cops.
 Metrics/LineLength:
+  Max: 120
   Exclude:
     - '*.gemspec'
+Metrics/ClassLength:
+  Max: 120
+
+# The danger_plugin.rb file presents unique challenges, ignore it.
+Metrics/MethodLength:
+  Exclude:
+    - 'lib/danger_plugin.rb'
+Metrics/PerceivedComplexity:
+  Exclude:
+    - 'lib/danger_plugin.rb'
+
+# I just don't like these ones.
+Metrics/AbcSize:
+  Enabled: false
+Metrics/CyclomaticComplexity:
+  Enabled: false
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 # Disable linting of Dangerfile.
-AllCops:
+Style/FrozenStringLiteralComment:
   Exclude:
     - 'Dangerfile'
 # Customize some cops.

--- a/Changelog.md
+++ b/Changelog.md
@@ -2,7 +2,7 @@
 
 ## Current Master
 
-- Nothing yet!
+- Integrates Rubocop linter to ensure code quality. See [#61](https://github.com/ashfurrow/danger-swiftlint/pull/61).
 
 ## 0.10.1
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -6,7 +6,7 @@ warn("Big PR, try to keep changes smaller if you can") if git.lines_of_code > 50
 
 no_changelog_entry = !git.modified_files.include?("Changelog.md")
 if has_app_changes && no_changelog_entry
-  warn("Any changes to library code should be reflected in the Changelog. Please consider adding a note there and adhere to the [Changelog Guidelines](https://github.com/Moya/contributors/blob/master/Changelog%20Guidelines.md).")
+  warn("Any changes to library code should be reflected in the Changelog. Please consider adding a note there.")
 end
 
 rubocop.lint

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,0 +1,12 @@
+has_app_changes = !git.modified_files.grep(/(bin|ext|lib)/).empty?
+
+warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"
+
+warn("Big PR, try to keep changes smaller if you can") if git.lines_of_code > 500
+
+no_changelog_entry = !git.modified_files.include?("Changelog.md")
+if has_app_changes && no_changelog_entry
+  warn("Any changes to library code should be reflected in the Changelog. Please consider adding a note there and adhere to the [Changelog Guidelines](https://github.com/Moya/contributors/blob/master/Changelog%20Guidelines.md).")
+end
+
+rubocop.lint

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,6 @@
+# Disable linting of Dangerfile.
+# rubocop:disable all
+
 has_app_changes = !git.modified_files.grep(/(bin|ext|lib)/).empty?
 
 warn("PR is classed as Work in Progress") if github.pr_title.include? "[WIP]"

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'danger'
+gem 'danger-rubocop'
+
 group :development do
   gem 'bacon'
   gem 'mocha'

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,9 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'mocha'
   gem 'bacon'
+  gem 'mocha'
   gem 'mocha-on-bacon'
   gem 'prettybacon'
+  gem 'rubocop', '~> 0.50.0', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
   specs:
     addressable (2.5.2)
       public_suffix (>= 2.0.2, < 4.0)
+    ast (2.3.0)
     bacon (1.2.0)
     claide (1.0.2)
     claide-plugins (0.9.2)
@@ -76,6 +77,10 @@ GEM
     octokit (4.7.0)
       sawyer (~> 0.8.0, >= 0.5.3)
     open4 (1.3.4)
+    parallel (1.12.0)
+    parser (2.4.0.0)
+      ast (~> 2.2)
+    powerpack (0.1.1)
     prettybacon (0.0.2)
       bacon (~> 1.2)
     pry (0.10.4)
@@ -83,6 +88,8 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     public_suffix (3.0.0)
+    rainbow (2.2.2)
+      rake
     rake (12.1.0)
     rb-fsevent (0.9.8)
     rb-inotify (0.9.8)
@@ -100,6 +107,14 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.5.0)
     rspec-support (3.5.0)
+    rubocop (0.50.0)
+      parallel (~> 1.10)
+      parser (>= 2.3.3.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 2.2.2, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.9.0)
     sawyer (0.8.1)
       addressable (>= 2.3.5, < 2.6)
       faraday (~> 0.8, < 1.0)
@@ -125,6 +140,7 @@ DEPENDENCIES
   prettybacon
   pry
   rspec (~> 3.4)
+  rubocop (~> 0.50.0)
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,9 @@ GEM
       no_proxy_fix
       octokit (~> 4.7)
       terminal-table (~> 1)
+    danger-rubocop (0.5.0)
+      danger
+      rubocop
     diff-lcs (1.3)
     faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
@@ -131,6 +134,8 @@ PLATFORMS
 DEPENDENCIES
   bacon
   bundler (~> 1.3)
+  danger
+  danger-rubocop
   danger-swiftlint!
   guard (~> 2.14)
   guard-rspec (~> 4.7)

--- a/Guardfile
+++ b/Guardfile
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 # A guardfile for making Danger Plugins
 # For more info see https://github.com/guard/guard#readme
 
 # To run, use `bundle exec guard`.
 
-guard :rspec, cmd: "bundle exec rspec" do
-  require "guard/rspec/dsl"
+guard :rspec, cmd: 'bundle exec rspec' do
+  require 'guard/rspec/dsl'
   dsl = Guard::RSpec::Dsl.new(self)
 
   # Feel free to open issues for suggestions and improvements

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 import 'ext/swiftlint/Rakefile'
 require 'bundler/gem_tasks'
-require "rspec/core/rake_task"
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
@@ -10,5 +12,4 @@ task :spec do
   Rake::Task['specs'].invoke
 end
 
-task :default => :spec
-
+task default: :spec

--- a/bin/danger-swiftlint
+++ b/bin/danger-swiftlint
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
 if $PROGRAM_NAME == __FILE__
   $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)

--- a/bin/danger-swiftlint
+++ b/bin/danger-swiftlint
@@ -7,6 +7,7 @@ end
 require 'thor'
 require 'version'
 
+# The class defining the CLI interface of the plugin.
 class DangerSwiftlintCLI < Thor
   desc 'version', 'The version of the installed danger-swiftlint plugin'
   def version

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+test:
+  pre:
+    - bundle exec danger

--- a/danger-swiftlint.gemspec
+++ b/danger-swiftlint.gemspec
@@ -1,4 +1,3 @@
-
 # frozen_string_literal: true
 
 lib = File.expand_path('../lib', __FILE__)

--- a/danger-swiftlint.gemspec
+++ b/danger-swiftlint.gemspec
@@ -1,4 +1,6 @@
-# coding: utf-8
+
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'version'
@@ -8,15 +10,15 @@ Gem::Specification.new do |spec|
   spec.version       = DangerSwiftlint::VERSION
   spec.authors       = ['Ash Furrow', 'David Grandinetti', 'Orta Therox', 'Thiago Felix', 'Giovanni Lodi']
   spec.email         = ['ash@ashfurrow.com', 'dbgrandi@gmail.com', 'orta.therox@gmail.com', 'thiago@thiagofelix.com', 'gio@mokacoding.com']
-  spec.description   = %q{A Danger plugin for linting Swift with SwiftLint.}
-  spec.summary       = %q{A Danger plugin for linting Swift with SwiftLint.}
+  spec.description   = 'A Danger plugin for linting Swift with SwiftLint.'
+  spec.summary       = 'A Danger plugin for linting Swift with SwiftLint.'
   spec.homepage      = 'https://github.com/ashfurrow/danger-swiftlint'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files`.split($/)
+  spec.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
-  spec.extensions    = %w(ext/swiftlint/Rakefile)
+  spec.extensions    = %w[ext/swiftlint/Rakefile]
   spec.executables   = ['danger-swiftlint']
 
   spec.add_dependency 'danger'
@@ -27,19 +29,18 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.3'
 
   #  Testing support
-  spec.add_development_dependency "rspec", '~> 3.4'
+  spec.add_development_dependency 'rspec', '~> 3.4'
 
   # Makes testing easy via `bundle exec guard`
-  spec.add_development_dependency "guard", '~> 2.14'
-  spec.add_development_dependency "guard-rspec", '~> 4.7'
+  spec.add_development_dependency 'guard', '~> 2.14'
+  spec.add_development_dependency 'guard-rspec', '~> 4.7'
 
   # If you want to work on older builds of ruby
-  spec.add_development_dependency "listen", '3.0.7'
+  spec.add_development_dependency 'listen', '3.0.7'
 
   # This gives you the chance to run a REPL inside your test
   # via
   #    binding.pry
   # This will stop test execution and let you inspect the results
-  spec.add_development_dependency "pry"
-
+  spec.add_development_dependency 'pry'
 end

--- a/ext/swiftlint/Rakefile
+++ b/ext/swiftlint/Rakefile
@@ -1,12 +1,13 @@
+# frozen_string_literal: true
+
 require_relative '../../lib/version'
 
 namespace :swiftlint do
-
-  desc "Download and install swiftlint tool"
+  desc 'Download and install swiftlint tool'
   task :install do
-    REPO = "https://github.com/realm/SwiftLint"
-    VERSION = ENV["SWIFTLINT_VERSION"] || DangerSwiftlint::SWIFTLINT_VERSION
-    ASSET = "portable_swiftlint.zip"
+    REPO = 'https://github.com/realm/SwiftLint'
+    VERSION = ENV['SWIFTLINT_VERSION'] || DangerSwiftlint::SWIFTLINT_VERSION
+    ASSET = 'portable_swiftlint.zip'
     URL = "#{REPO}/releases/download/#{VERSION}/#{ASSET}"
     DESTINATION = File.expand_path(File.join(File.dirname(__FILE__), 'bin'))
 
@@ -16,9 +17,8 @@ namespace :swiftlint do
       "curl -s -L #{URL} -o #{ASSET}",
       "unzip -q #{ASSET} -d #{DESTINATION}",
       "rm #{ASSET}"
-    ].join(" && ")
+    ].join(' && ')
   end
-
 end
 
 task default: 'swiftlint:install'

--- a/ext/swiftlint/swiftlint.rb
+++ b/ext/swiftlint/swiftlint.rb
@@ -1,15 +1,15 @@
 
+# frozen_string_literal: true
+
 class Swiftlint
-  def initialize(swiftlint_path=nil)
+  def initialize(swiftlint_path = nil)
     @swiftlint_path = swiftlint_path
   end
 
   # Runs swiftlint
-  def run(cmd='lint', additional_swiftlint_args='', options={})
+  def run(cmd = 'lint', additional_swiftlint_args = '', options = {})
     # change pwd before run swiftlint
-    if options.has_key? :pwd
-      Dir.chdir options.delete(:pwd)
-    end
+    Dir.chdir options.delete(:pwd) if options.key? :pwd
 
     # run swiftlint with provided options
     `#{swiftlint_path} #{cmd} #{swiftlint_arguments(options, additional_swiftlint_args)}`
@@ -27,7 +27,7 @@ class Swiftlint
 
   # Return swiftlint execution path
   def swiftlint_path
-    @swiftlint_path or default_swiftlint_path
+    @swiftlint_path || default_swiftlint_path
   end
 
   private
@@ -35,10 +35,10 @@ class Swiftlint
   # Parse options into shell arguments how swift expect it to be
   # more information: https://github.com/Carthage/Commandant
   # @param options (Hash) hash containing swiftlint options
-  def swiftlint_arguments (options, additional_swiftlint_args)
+  def swiftlint_arguments(options, additional_swiftlint_args)
     (options.
       # filter not null
-      select {|key, value| !value.nil?}.
+      reject { |_key, value| value.nil? }.
       # map booleans arguments equal true
       map { |key, value| value.is_a?(TrueClass) ? [key, ''] : [key, value] }.
       # map booleans arguments equal false
@@ -48,7 +48,7 @@ class Swiftlint
       # prepend '--' into the argument
       map { |key, value| ["--#{key}", value] }.
       # reduce everything into a single string
-      reduce('') { |args, option| "#{args} #{option[0]} #{option[1]}"} + 
+      reduce('') { |args, option| "#{args} #{option[0]} #{option[1]}" } +
       " #{additional_swiftlint_args}").
       # strip leading spaces
       strip

--- a/ext/swiftlint/swiftlint.rb
+++ b/ext/swiftlint/swiftlint.rb
@@ -1,6 +1,6 @@
-
 # frozen_string_literal: true
 
+# A wrapper to use SwiftLint via a Ruby API.
 class Swiftlint
   def initialize(swiftlint_path = nil)
     @swiftlint_path = swiftlint_path
@@ -21,7 +21,7 @@ class Swiftlint
   end
 
   # Return true if swiftlint is installed or false otherwise
-  def is_installed?
+  def installed?
     File.exist?(swiftlint_path)
   end
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -47,12 +47,10 @@ module Danger
       raise 'swiftlint is not installed' unless swiftlint.installed?
 
       config = if config_file
-        File.expand_path(config_file)
-      elsif File.file?('.swiftlint.yml')
-        File.expand_path('.swiftlint.yml')
-      else
-        nil
-      end
+                 File.expand_path(config_file)
+               elsif File.file?('.swiftlint.yml')
+                 File.expand_path('.swiftlint.yml')
+               end
       log "Using config file: #{config}"
 
       dir_selected = directory ? File.expand_path(directory) : Dir.pwd
@@ -95,7 +93,7 @@ module Danger
 
         # Fail Danger on errors
         if fail_on_error && errors.count.positive?
-          fail 'Failed due to SwiftLint errors'
+          raise 'Failed due to SwiftLint errors'
         end
       end
     end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,4 +1,6 @@
+# frozen_string_literal: true
+
 module DangerSwiftlint
-  VERSION = "0.10.1".freeze
-  SWIFTLINT_VERSION = "0.20.1".freeze
+  VERSION = '0.10.0'
+  SWIFTLINT_VERSION = '0.20.1'
 end

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -6,3 +6,6 @@ Metrics/LineLength:
 
 Metrics/BlockLength:
   Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false

--- a/spec/.rubocop.yml
+++ b/spec/.rubocop.yml
@@ -1,0 +1,8 @@
+# In the context of unit test with RSpec it is acceptable to have long blocks
+# and long lines, at times the behaviour we need to describe might be a bit
+# lengthy, require some setup, have a number of edge cases.
+Metrics/LineLength:
+  Enabled: false
+
+Metrics/BlockLength:
+  Enabled: false

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -15,7 +15,7 @@ module Danger
       end
 
       it 'handles swiftlint not being installed' do
-        allow_any_instance_of(Swiftlint).to receive(:is_installed?).and_return(false)
+        allow_any_instance_of(Swiftlint).to receive(:installed?).and_return(false)
         expect { @swiftlint.lint_files }.to raise_error('swiftlint is not installed')
       end
 
@@ -37,7 +37,7 @@ module Danger
 
       describe :lint_files do
         before do
-          allow_any_instance_of(Swiftlint).to receive(:is_installed?).and_return(true)
+          allow_any_instance_of(Swiftlint).to receive(:installed?).and_return(true)
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([])
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../spec_helper', __FILE__)
 
 module Danger
@@ -12,9 +14,9 @@ module Danger
         allow(@swiftlint.git).to receive(:deleted_files).and_return([])
       end
 
-      it "handles swiftlint not being installed" do
+      it 'handles swiftlint not being installed' do
         allow_any_instance_of(Swiftlint).to receive(:is_installed?).and_return(false)
-        expect { @swiftlint.lint_files }.to raise_error("swiftlint is not installed")
+        expect { @swiftlint.lint_files }.to raise_error('swiftlint is not installed')
       end
 
       it 'does not markdown an empty message' do
@@ -44,29 +46,29 @@ module Danger
 
         it 'accept files as arguments' do
           expect_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')), '')
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
             .and_return(@swiftlint_response)
 
-          @swiftlint.lint_files("spec/fixtures/*.swift")
+          @swiftlint.lint_files('spec/fixtures/*.swift')
 
           output = @swiftlint.status_report[:markdowns].first.to_s
-          expect(output).to include("SwiftLint found issues")
-          expect(output).to include("SwiftFile.swift | 13 | Force casts should be avoided.")
+          expect(output).to include('SwiftLint found issues')
+          expect(output).to include('SwiftFile.swift | 13 | Force casts should be avoided.')
         end
 
         it 'accepts additional cli arguments' do
           expect_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')), '--lenient')
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '--lenient')
             .and_return(@swiftlint_response)
 
-          @swiftlint.lint_files("spec/fixtures/*.swift", additional_swiftlint_args: '--lenient')
+          @swiftlint.lint_files('spec/fixtures/*.swift', additional_swiftlint_args: '--lenient')
         end
 
         it 'uses git diff when files are not provided' do
           allow(@swiftlint.git).to receive(:modified_files).and_return(['spec/fixtures/SwiftFile.swift'])
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')), '')
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
             .and_return(@swiftlint_response)
 
           @swiftlint.lint_files
@@ -79,29 +81,28 @@ module Danger
           @swiftlint.directory = 'spec/fixtures/some_dir'
 
           allow_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:pwd => File.expand_path(@swiftlint.directory)), '')
+            .with(hash_including(pwd: File.expand_path(@swiftlint.directory)), '')
             .and_return(@swiftlint_response)
 
-          @swiftlint.lint_files(["spec/fixtures/some_dir/SwiftFile.swift"])
+          @swiftlint.lint_files(['spec/fixtures/some_dir/SwiftFile.swift'])
 
           output = @swiftlint.status_report[:markdowns].first.to_s
           expect(output).to_not be_empty
-          
         end
 
         it 'only lint files specified in custom dir' do
           @swiftlint.directory = 'spec/fixtures/some_dir'
-        
+
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([
-            'spec/fixtures/some_dir/SwiftFile.swift',
-            'spec/fixtures/SwiftFile.swift'
-          ])
+                                                                         'spec/fixtures/some_dir/SwiftFile.swift',
+                                                                         'spec/fixtures/SwiftFile.swift'
+                                                                       ])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
-          .with(hash_including(:path => File.expand_path('spec/fixtures/some_dir/SwiftFile.swift')), '')
-          .once
-          .and_return(@swiftlint_response)
+            .with(hash_including(path: File.expand_path('spec/fixtures/some_dir/SwiftFile.swift')), '')
+            .once
+            .and_return(@swiftlint_response)
 
           @swiftlint.lint_files
         end
@@ -127,13 +128,13 @@ module Danger
         it 'does not lint files in the excluded paths' do
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([
-            'spec/fixtures/SwiftFile.swift',
-            'spec/fixtures/excluded_dir/SwiftFileThatShouldNotBeIncluded.swift',
-            'spec/fixtures/excluded_dir/SwiftFile WithEscaped+CharactersThatShouldNotBeIncluded.swift'
-          ])
+                                                                         'spec/fixtures/SwiftFile.swift',
+                                                                         'spec/fixtures/excluded_dir/SwiftFileThatShouldNotBeIncluded.swift',
+                                                                         'spec/fixtures/excluded_dir/SwiftFile WithEscaped+CharactersThatShouldNotBeIncluded.swift'
+                                                                       ])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')), '')
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
             .once
             .and_return(@swiftlint_response)
 
@@ -144,11 +145,11 @@ module Danger
         it 'does not crash when excluded is nil' do
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([
-            'spec/fixtures/SwiftFile.swift',
-          ])
+                                                                         'spec/fixtures/SwiftFile.swift'
+                                                                       ])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')), '')
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
             .once
             .and_return(@swiftlint_response)
 
@@ -208,15 +209,15 @@ module Danger
           # they'd result in file not found errors.
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([
-            'spec/fixtures/SwiftFile.swift',
-            'spec/fixtures/DeletedFile.swift'
-          ])
+                                                                         'spec/fixtures/SwiftFile.swift',
+                                                                         'spec/fixtures/DeletedFile.swift'
+                                                                       ])
           allow(@swiftlint.git).to receive(:deleted_files).and_return([
-            'spec/fixtures/DeletedFile.swift'
-          ])
+                                                                        'spec/fixtures/DeletedFile.swift'
+                                                                      ])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')), '')
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
             .once
             .and_return(@swiftlint_response)
 
@@ -225,10 +226,10 @@ module Danger
 
         it 'generates errors instead of markdown when use inline mode' do
           allow_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:path => File.expand_path('spec/fixtures/SwiftFile.swift')), '')
+            .with(hash_including(path: File.expand_path('spec/fixtures/SwiftFile.swift')), '')
             .and_return(@swiftlint_response)
 
-          @swiftlint.lint_files("spec/fixtures/*.swift", inline_mode: true, fail_on_error: false, additional_swiftlint_args: '')
+          @swiftlint.lint_files('spec/fixtures/*.swift', inline_mode: true, fail_on_error: false, additional_swiftlint_args: '')
 
           status = @swiftlint.status_report
           expect(status[:errors]).to_not be_empty

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -160,11 +160,11 @@ module Danger
         it 'default config is nil, unspecified' do
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([
-            'spec/fixtures/SwiftFile.swift',
-          ])
+                                                                         'spec/fixtures/SwiftFile.swift'
+                                                                       ])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:config => nil), '')
+            .with(hash_including(config: nil), '')
             .once
             .and_return(@swiftlint_response)
 
@@ -174,13 +174,13 @@ module Danger
         it 'expands default config file (if present) to absolute path' do
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([
-            'spec/fixtures/SwiftFile.swift',
-          ])
+                                                                         'spec/fixtures/SwiftFile.swift'
+                                                                       ])
           expect(File).to receive(:file?).and_return(true)
           expect(YAML).to receive(:load_file).and_return({})
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:config => File.expand_path('.swiftlint.yml')), '')
+            .with(hash_including(config: File.expand_path('.swiftlint.yml')), '')
             .once
             .and_return(@swiftlint_response)
 
@@ -190,11 +190,11 @@ module Danger
         it 'expands specified config file to absolute path' do
           allow(@swiftlint.git).to receive(:added_files).and_return([])
           allow(@swiftlint.git).to receive(:modified_files).and_return([
-            'spec/fixtures/SwiftFile.swift',
-          ])
+                                                                         'spec/fixtures/SwiftFile.swift'
+                                                                       ])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(:config => File.expand_path('spec/fixtures/some_config.yml')), '')
+            .with(hash_including(config: File.expand_path('spec/fixtures/some_config.yml')), '')
             .once
             .and_return(@swiftlint_response)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 require 'pathname'
 
 ROOT = Pathname.new(File.expand_path('../../', __FILE__))
-$:.unshift((ROOT + 'lib').to_s)
-$:.unshift((ROOT + 'spec').to_s)
+$LOAD_PATH.unshift((ROOT + 'lib').to_s)
+$LOAD_PATH.unshift((ROOT + 'spec').to_s)
 
 RSpec.configure do |config|
- # Use color in STDOUT
+  # Use color in STDOUT
   config.color = true
 end
 
 RSpec::Matchers.define :including do |x|
-  match { |actual| actual.include? x  }
+  match { |actual| actual.include? x }
 end
 
 require 'bundler/setup'
@@ -32,11 +34,11 @@ end
 # running a PR on TravisCI
 def testing_env
   {
-    "HAS_JOSH_K_SEAL_OF_APPROVAL" => "true",
-    "TRAVIS_PULL_REQUEST" => "800",
-    "TRAVIS_REPO_SLUG" => "artsy/eigen",
-    "TRAVIS_COMMIT_RANGE" => "759adcbd0d8f...13c4dc8bb61d",
-    "DANGER_GITHUB_API_TOKEN" => "123sbdq54erfsd3422gdfio"
+    'HAS_JOSH_K_SEAL_OF_APPROVAL' => 'true',
+    'TRAVIS_PULL_REQUEST' => '800',
+    'TRAVIS_REPO_SLUG' => 'artsy/eigen',
+    'TRAVIS_COMMIT_RANGE' => '759adcbd0d8f...13c4dc8bb61d',
+    'DANGER_GITHUB_API_TOKEN' => '123sbdq54erfsd3422gdfio'
   }
 end
 

--- a/spec/swiftlint_spec.rb
+++ b/spec/swiftlint_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('../spec_helper', __FILE__)
 require_relative '../ext/swiftlint/swiftlint'
 
@@ -25,7 +27,7 @@ describe Swiftlint do
 
   it 'runs lint by default with options being optional' do
     expect(swiftlint).to receive(:`).with(including('swiftlint lint'))
-    swiftlint.run()
+    swiftlint.run
   end
 
   it 'runs accepting symbolized options' do
@@ -36,8 +38,6 @@ describe Swiftlint do
                   '',
                   use_stdin: false,
                   cache_path: '/path',
-                  enable_all_rules: true
-                  )
+                  enable_all_rules: true)
   end
 end
-

--- a/spec/swiftlint_spec.rb
+++ b/spec/swiftlint_spec.rb
@@ -5,23 +5,23 @@ require_relative '../ext/swiftlint/swiftlint'
 
 describe Swiftlint do
   let(:swiftlint) { Swiftlint.new }
-  it 'is_installed? works based on bin/swiftlint file' do
-    expect(File).to receive(:exist?).with(/bin\/swiftlint/).and_return(true)
-    expect(swiftlint.is_installed?).to be_truthy
+  it 'installed? works based on bin/swiftlint file' do
+    expect(File).to receive(:exist?).with(%r{/bin\/swiftlint}).and_return(true)
+    expect(swiftlint.installed?).to be_truthy
 
-    expect(File).to receive(:exist?).with(/bin\/swiftlint/).and_return(false)
-    expect(swiftlint.is_installed?).to be_falsy
+    expect(File).to receive(:exist?).with(%r{bin\/swiftlint}).and_return(false)
+    expect(swiftlint.installed?).to be_falsy
   end
 
   context 'with binary_path' do
     let(:binary_path) { '/path/to/swiftlint' }
     let(:swiftlint) { Swiftlint.new(binary_path) }
-    it 'is_installed? works based on specific path' do
+    it 'installed? works based on specific path' do
       expect(File).to receive(:exist?).with(binary_path).and_return(true)
-      expect(swiftlint.is_installed?).to be_truthy
+      expect(swiftlint.installed?).to be_truthy
 
       expect(File).to receive(:exist?).with(binary_path).and_return(false)
-      expect(swiftlint.is_installed?).to be_falsy
+      expect(swiftlint.installed?).to be_falsy
     end
   end
 


### PR DESCRIPTION
This PR addresses #1, by installing Rubocop, running it with `--auto-fix`, and fixing all the remaining offences that were straightforward.

Since in #1  no particular style was mentioned, I think we should just go with whichever defaults the Rubocop style guide suggests.

The only exceptions I took the liberty of making have been:

- Line length in the `.gemspec`, for the sake of keeping the tabbed formatting consistent
- Line and block length in the `spec/` folder (_see comment in `spec/.rubocop.yml`)

Things still to do:

- Lint PRs with https://github.com/ashfurrow/danger-rubocop
- Address the remaining offences, which might require a bit of code redesign and would make this PR too long

For the record, here's the remaining offences:

```
Inspecting 12 files
......CC.C..

Offenses:

ext/swiftlint/swiftlint.rb:15:81: C: Line is too long. [89/80]
    `#{swiftlint_path} #{cmd} #{swiftlint_arguments(options, additional_swiftlint_args)}`
                                                                                ^^^^^^^^^
ext/swiftlint/swiftlint.rb:38:3: C: Assignment Branch Condition size for swiftlint_arguments is too high. [15.13/15]
  def swiftlint_arguments(options, additional_swiftlint_args)
  ^^^
ext/swiftlint/swiftlint.rb:45:81: C: Line is too long. [86/80]
      map { |key, value| value.is_a?(FalseClass) ? ["no-#{key}", ''] : [key, value] }.
                                                                                ^^^^^^
lib/danger_plugin.rb:22:3: C: Class has too many lines. [107/100]
  class DangerSwiftlint < Plugin ...
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/danger_plugin.rb:45:5: C: Assignment Branch Condition size for lint_files is too high. [46.24/15]
    def lint_files(files = nil, inline_mode: false, fail_on_error: false, additional_swiftlint_args: '')
    ^^^
lib/danger_plugin.rb:45:5: C: Cyclomatic complexity for lint_files is too high. [12/6]
    def lint_files(files = nil, inline_mode: false, fail_on_error: false, additional_swiftlint_args: '')
    ^^^
lib/danger_plugin.rb:45:5: C: Method has too many lines. [35/10]
    def lint_files(files = nil, inline_mode: false, fail_on_error: false, additional_swiftlint_args: '') ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
lib/danger_plugin.rb:45:5: C: Perceived complexity for lint_files is too high. [14/7]
    def lint_files(files = nil, inline_mode: false, fail_on_error: false, additional_swiftlint_args: '')
    ^^^
lib/danger_plugin.rb:45:81: C: Line is too long. [104/80]
    def lint_files(files = nil, inline_mode: false, fail_on_error: false, additional_swiftlint_args: '')
                                                                                ^^^^^^^^^^^^^^^^^^^^^^^^
lib/danger_plugin.rb:107:81: C: Line is too long. [87/80]
        .map { |full_options| swiftlint.lint(full_options, additional_swiftlint_args) }
                                                                                ^^^^^^^
lib/danger_plugin.rb:117:5: C: Assignment Branch Condition size for find_swift_files is too high. [25.04/15]
    def find_swift_files(dir_selected, files = nil, excluded_paths = [])
    ^^^
lib/danger_plugin.rb:117:5: C: Method has too many lines. [18/10]
    def find_swift_files(dir_selected, files = nil, excluded_paths = []) ...
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
spec/danger_plugin_spec.rb:5:1: C: Module has too many lines. [173/100]
module Danger ...
^^^^^^^^^^^^^

12 files inspected, 13 offenses detected
```