### PR TITLE
Add escaping for 'directory' variable

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Integrates Rubocop linter to ensure code quality. See [#61](https://github.com/ashfurrow/danger-swiftlint/pull/61).
+- Fixes issue where `directory` variable was not escaped. See [62](https://github.com/ashfurrow/danger-swiftlint/issues/62).
 
 ## 0.10.1
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -53,7 +53,7 @@ module Danger
                end
       log "Using config file: #{config}"
 
-      dir_selected = directory ? File.expand_path(directory) : Dir.pwd
+      dir_selected = directory ? File.expand_path(directory) : Shellwords.escape(Dir.pwd)
       log "Swiftlint will be run from #{dir_selected}"
 
       # Extract excluded paths

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -91,10 +91,9 @@ module Danger
         end
 
         it 'uses escaped pwd when directory is not set' do
-
           allow_any_instance_of(Swiftlint).to receive(:lint)
-          .with(hash_including(pwd: File.expand_path('.')), '')
-          .and_return(@swiftlint_response)
+            .with(hash_including(pwd: File.expand_path('.')), '')
+            .and_return(@swiftlint_response)
 
           @swiftlint.lint_files(['spec/fixtures/some\ dir/SwiftFile.swift'])
 

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -90,6 +90,18 @@ module Danger
           expect(output).to_not be_empty
         end
 
+        it 'uses escaped pwd when directory is not set' do
+
+          allow_any_instance_of(Swiftlint).to receive(:lint)
+          .with(hash_including(pwd: File.expand_path('.')), '')
+          .and_return(@swiftlint_response)
+
+          @swiftlint.lint_files(['spec/fixtures/some\ dir/SwiftFile.swift'])
+
+          output = @swiftlint.status_report[:markdowns].first.to_s
+          expect(output).to_not be_empty
+        end
+
         it 'only lint files specified in custom dir' do
           @swiftlint.directory = 'spec/fixtures/some_dir'
 

--- a/spec/fixtures/some dir/SwiftFile.swift
+++ b/spec/fixtures/some dir/SwiftFile.swift
@@ -1,0 +1,1 @@
+// This file intentional left blank-ish.


### PR DESCRIPTION
This PR fixes issue described in #62 
Thanks for fast response, @ashfurrow 😊