### PR TITLE
#trivial: README updated to include .directory option and clarification on included files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The easiest way to use is just add this to your Dangerfile:
 swiftlint.lint_files
 ```
 
-That's going to lint all your Swift files. It would be better to only lint the changed or added ones, which is complicated due. Check out [this issue](https://github.com/ashfurrow/danger-swiftlint/issues/16) for more details.
+By default danger-swiftlint will lint added and modified files. 
 
 ```rb
 swiftlint.config_file = '.swiftlint.yml'
@@ -32,6 +32,12 @@ swiftlint.lint_files
 ```
 
 If you want the lint result shows in diff instead of comment, you can use `inline_mode` option. Violations that out of the diff will show in danger's fail or warn section.
+
+```rb
+swiftlint.directory "Directory A"
+```
+
+Lint different directories individually
 
 ```rb
 swiftlint.lint_files inline_mode: true

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you want the lint result shows in diff instead of comment, you can use `inlin
 swiftlint.directory "Directory A"
 ```
 
-Lint different directories individually
+If you want different configurations on different directories, you can specify the directory. Note: Run `swiftlint.lint_files` per specified directory then.
 
 ```rb
 swiftlint.lint_files inline_mode: true


### PR DESCRIPTION
I think a good README is essential to success for a great project.
This is certainly a great project, but I spend quite a while (too much that it would still be funny) trying to figure out why the lint issues that I've seen locally wouldn't show up on Danger.

Turns out, #16 made the plugin only lint files that have been modified or added. README referenced #16 but said it was linting all files, which is definitely false. 
After a dozen runs on debug thinking there was a error on selecting my files, dealing with the ?
`included` option on the SwiftLint config and the `directory` option on this plugin, I came to the conclusion that setting directory still only lints modified files on PRs.

Therefore I added:
* Removed README's reference to #16 as it's closed now
* Clarified which files are going to be lint
* Clarified the `directory` option