### PR TITLE
Fix configuration error

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Current Master
 
 - Removes test fixtures from gemspec.
+- Fixes [#68](https://github.com/ashfurrow/danger-swiftlint/issues/68), specifying a config file directly should work again.
 
 ## 0.11.0
 

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -50,7 +50,7 @@ module Danger
       raise 'swiftlint is not installed' unless swiftlint.installed?
 
       config = if config_file
-                 File.expand_path(config_file)
+                 config_file
                elsif File.file?('.swiftlint.yml')
                  File.expand_path('.swiftlint.yml')
                end

--- a/spec/danger_plugin_spec.rb
+++ b/spec/danger_plugin_spec.rb
@@ -221,7 +221,7 @@ module Danger
                                                                        ])
 
           expect_any_instance_of(Swiftlint).to receive(:lint)
-            .with(hash_including(config: File.expand_path('spec/fixtures/some_config.yml')), '')
+            .with(hash_including(config: 'spec/fixtures/some_config.yml'), '')
             .once
             .and_return(@swiftlint_response)
 


### PR DESCRIPTION
When a configuration file is specified with the config-file setting, this path should be honored. As pointed out in the [issue](https://github.com/ashfurrow/danger-swiftlint/issues/68) description, [this](https://github.com/ashfurrow/danger-swiftlint/commit/1368b6606a0549c9306d79f487b750e79493ab53#diff-8779f9203f0e53486f80fde88b1552c9R44) introduced a path extension causing an error when specifying a path directly. This PR reverts that change and fixes this issue.

Fixes #68 