### PR TITLE
Fix issues with non-escaped folder paths

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,7 @@
 
 - Removes test fixtures from gemspec.
 - Fixes [#68](https://github.com/ashfurrow/danger-swiftlint/issues/68), specifying a config file directly should work again.
+- Fixes issue with non-escaping paths. Reverts [#63](https://github.com/ashfurrow/danger-swiftlint/pull/63).
 
 ## 0.11.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    danger-swiftlint (0.10.2)
+    danger-swiftlint (0.11.0)
       danger
       rake (> 10)
       thor (~> 0.19)
@@ -148,4 +148,4 @@ DEPENDENCIES
   rubocop (~> 0.50.0)
 
 BUNDLED WITH
-   1.15.4
+   1.16.0


### PR DESCRIPTION
This PR addresses issues with folder paths containing whitespaces (in our case it is similar to "Project Name" and containing folder with source files has same "Project name" too).

- First of all it removes changes made by #63 (sorry). 
  **Reason:** It was wrong to escape Dir.pwd on that level since when it was used [here](https://github.com/ashfurrow/danger-swiftlint/blob/af613b1ded2cecd6cdd8d190154ac8d8b7e21bda/ext/swiftlint/swiftlint.rb#L12) it was causing and error because `Dir.chdir` for some reason fails if path is escaped
**Solution:** escape dir_selected only in `find_swift_files` where it is compared with escaped files paths

- Fixes escaping in `find_swift_files` function.
   **Reason:** When relative file path was first escaped and only after expanded it was producing such results in our case:
```
 relative file path: 
"Project\ Name/Swiftlinttestfile.swift"
 absolute file path: 
"/Users/user/Documents/Projects/Project Name/Project\  Name/Swiftlinttestfile.swift"
```
which resulted in unusable file path/

  **Solution:** First expand, then escape. Also escape used dir_selected in this function because in other case this code will return no files every time:
```
       # Ensure only files in the selected directory
        select { |file| file.start_with?(dir_selected) }.
```