### PR TITLE
Add option to lint all files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Next
 
-- Nothing yet!
+- Addded `lintAllFiles` option to `SwiftLint.lint()`. This will lint all existing files (instead of just the added/modified ones). However, nested configurations works when this option is enabled.
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,17 @@ SwiftLint.lint(directory: "Sources", configFile: ".swiftlint.yml")
 SwiftLint.lint(directory: "Tests", configFile: "Tests/HarveyTests/.swiftlint.yml")
 ```
 
-It's not possible to use [nested configurations](https://github.com/realm/SwiftLint#nested-configurations), because Danger SwiftLint lints each file on it's own, and by doing that the nested configuration is disabled. If you want to learn more details about this, read the whole issue [here](https://github.com/ashfurrow/danger-swiftlint/issues/4).
+### Lint all files
+
+By default, only files that were added or modified are linted.
+
+It's not possible to use [nested configurations](https://github.com/realm/SwiftLint#nested-configurations) in that case, because Danger SwiftLint lints each file on it's own, and by doing that the nested configuration is disabled. If you want to learn more details about this, read the whole issue [here](https://github.com/ashfurrow/danger-swiftlint/issues/4).
+
+However, you can use the `lintAllFiles` option to lint all the files. In that case, Danger SwiftLint doesn't lint files individually, which makes nested configuration to work. It'd be the same as you were running `swiftlint` on the root folder:
+
+```swift
+SwiftLint.lint(lintAllFiles: true)
+```
 
 # Contributing
 

--- a/Sources/DangerSwiftLint/CurrentPathProvider.swift
+++ b/Sources/DangerSwiftLint/CurrentPathProvider.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+internal protocol CurrentPathProvider {
+    var currentPath: String { get }
+}
+
+internal final class DefaultCurrentPathProvider: CurrentPathProvider {
+    var currentPath: String {
+        return ShellExecutor().execute("pwd")
+    }
+}

--- a/Tests/DangerSwiftLintTests/FakeCurrentPathProvider.swift
+++ b/Tests/DangerSwiftLintTests/FakeCurrentPathProvider.swift
@@ -1,0 +1,5 @@
+@testable import DangerSwiftLint
+
+final class FakeCurrentPathProvider: CurrentPathProvider {
+    var currentPath: String = ""
+}


### PR DESCRIPTION
Given that this is a new option and the "Customizing" section on README, it's okay if you feel like this shouldn't be merged. Just wanted to contribute back if this is something useful overall.

The main motivation here is to keep nested configurations working (#4) as the proposed solution requires us to specify another full configuration file.

The downside of this mode is that all files would be linted (not only the added/modified) which is not a problem in my usecase but might be for some people.