### PR TITLE
Allow setting a custom SwiftLint binary path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 ## Next
 
-- Nothing yet!
+- Added `swiftlintPath` option to `SwiftLint.lint()`. This allows providing a custom path if you want to use a specific binary instead of the global one (e.g. when using CocoaPods).
 
 ## 0.4.0
 
-- Addded `lintAllFiles` option to `SwiftLint.lint()`. This will lint all existing files (instead of just the added/modified ones). However, nested configurations works when this option is enabled.
+- Added `lintAllFiles` option to `SwiftLint.lint()`. This will lint all existing files (instead of just the added/modified ones). However, nested configurations works when this option is enabled.
 
 ## 0.3.0
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ However, you can use the `lintAllFiles` option to lint all the files. In that ca
 SwiftLint.lint(lintAllFiles: true)
 ```
 
+### Custom SwiftLint binary path
+
+By default, Danger SwiftLint runs `swiftlint` assuming it's installed globally. However, there're cases where it makes sense to use a different path. One example would be if you've installed SwiftLint using [CocoaPods](https://github.com/CocoaPods/CocoaPods).
+
+To use another binary, you can use the `swiftlintPath` option:
+
+```swift
+SwiftLint.lint(swiftlintPath: "Pods/SwiftLint/swiftlint")
+```
+
 # Contributing
 
 If you find a bug, please [open an issue](https://github.com/ashfurrow/danger-swiftlint/issues/new)! Or a pull request :wink: 

--- a/Sources/DangerSwiftLint/DangerSwiftLint.swift
+++ b/Sources/DangerSwiftLint/DangerSwiftLint.swift
@@ -8,10 +8,13 @@ public struct SwiftLint {
     /// This is the main entry point for linting Swift in PRs using Danger-Swift.
     /// Call this function anywhere from within your Dangerfile.swift.
     @discardableResult
-    public static func lint(inline: Bool = false, directory: String? = nil, configFile: String? = nil, lintAllFiles: Bool = false) -> [Violation] {
+    public static func lint(inline: Bool = false, directory: String? = nil, 
+                            configFile: String? = nil, lintAllFiles: Bool = false,
+                            swiftlintPath: String = "swiftlint") -> [Violation] {
         // First, for debugging purposes, print the working directory.
         print("Working directory: \(shellExecutor.execute("pwd"))")
-        return self.lint(danger: danger, shellExecutor: shellExecutor, inline: inline, directory: directory, configFile: configFile, lintAllFiles: lintAllFiles)
+        return self.lint(danger: danger, shellExecutor: shellExecutor, inline: inline, directory: directory, 
+                         configFile: configFile, lintAllFiles: lintAllFiles, swiftlintPath: swiftlintPath)
     }
 }
 
@@ -24,6 +27,7 @@ internal extension SwiftLint {
         directory: String? = nil,
         configFile: String? = nil,
         lintAllFiles: Bool = false,
+        swiftlintPath: String = "swiftlint",
         currentPathProvider: CurrentPathProvider = DefaultCurrentPathProvider(),
         markdownAction: (String) -> Void = markdown,
         failAction: (String) -> Void = fail,
@@ -40,7 +44,7 @@ internal extension SwiftLint {
             if let configFile = configFile {
                 arguments.append("--config \"\(configFile)\"")
             }
-            let outputJSON = shellExecutor.execute("swiftlint", arguments: arguments)
+            let outputJSON = shellExecutor.execute(swiftlintPath, arguments: arguments)
             violations = makeViolations(from: outputJSON, failAction: failAction)
         } else {
             var files = danger.git.createdFiles + danger.git.modifiedFiles
@@ -53,7 +57,7 @@ internal extension SwiftLint {
                 if let configFile = configFile {
                     arguments.append("--config \"\(configFile)\"")
                 }
-                let outputJSON = shellExecutor.execute("swiftlint", arguments: arguments)
+                let outputJSON = shellExecutor.execute(swiftlintPath, arguments: arguments)
                 return makeViolations(from: outputJSON, failAction: failAction)
             }
         }

--- a/Tests/DangerSwiftLintTests/DangerSwiftLintTests.swift
+++ b/Tests/DangerSwiftLintTests/DangerSwiftLintTests.swift
@@ -22,6 +22,13 @@ class DangerSwiftLintTests: XCTestCase {
     func testExecutesTheShell() {
         _ = SwiftLint.lint(danger: danger, shellExecutor: executor, currentPathProvider: fakePathProvider)
         XCTAssertNotEqual(executor.invocations.dropFirst().count, 0)
+        XCTAssertEqual(executor.invocations.first?.command, "swiftlint")
+    }
+
+    func testExecutesTheShellWithCustomSwiftLintPath() {
+        _ = SwiftLint.lint(danger: danger, shellExecutor: executor, swiftlintPath: "Pods/SwiftLint/swiftlint", currentPathProvider: fakePathProvider)
+        XCTAssertNotEqual(executor.invocations.dropFirst().count, 0)
+        XCTAssertEqual(executor.invocations.first?.command, "Pods/SwiftLint/swiftlint")
     }
 
     func testExecuteSwiftLintInInlineMode() {


### PR DESCRIPTION
Homebrew doesn't allow to specify a version easily, so we currently use another way to install SwiftLint.

This PR adds support to provide a custom path, so it's pretty flexible. This is similar to what the [ruby version](https://github.com/ashfurrow/danger-ruby-swiftlint) has.